### PR TITLE
High res time for node

### DIFF
--- a/lithium.js
+++ b/lithium.js
@@ -22,7 +22,10 @@ performance.now = (function() {
          performance.msNow     ||
          performance.oNow      ||
          performance.webkitNow ||
-         function() { return new Date().getTime(); };
+         function() {
+            var hrTime = process.hrtime();
+            return (hrTime[0] + (hrTime[1] / 1000000));
+         };
 })();
 
 Li = {


### PR DESCRIPTION
Node doesn't have performance.now() but has process.hrtime() this will return a high res time result
